### PR TITLE
Add inheritsOpts to s2s-utils

### DIFF
--- a/packages/babel-plugin-s2s-reducer-root/src/index.js
+++ b/packages/babel-plugin-s2s-reducer-root/src/index.js
@@ -5,7 +5,7 @@ import { removeFlowComment, addFlowComment } from 'babel-add-flow-comments'
 import globby from 'globby'
 import upperCamelCase from 'uppercamelcase'
 import type { Path, State } from 's2s-babel-flow-types'
-import { getImportPath, template } from 's2s-utils'
+import { getImportPath, template, inheritsOpts } from 's2s-utils'
 
 const builders = {
   redux: template(`import { combineReducers } from 'redux'`),
@@ -15,16 +15,6 @@ const builders = {
 function getParentDirName(path: string) {
   const parentPath = normalize(dirname(path)).split('/')
   return upperCamelCase(parentPath[parentPath.length - 1])
-}
-
-// TODO ignore all syntax error
-function inheritsOpts() {
-  return {
-    manipulateOptions(opts: Object, parserOpts: Object) {
-      parserOpts.plugins.push('flow')
-      parserOpts.plugins.push('objectRestSpread')
-    },
-  }
 }
 
 export default () => {

--- a/packages/babel-plugin-s2s-state-root/src/index.js
+++ b/packages/babel-plugin-s2s-state-root/src/index.js
@@ -5,7 +5,7 @@ import { removeFlowComment, addFlowComment } from 'babel-add-flow-comments'
 import globby from 'globby'
 import upperCamelCase from 'uppercamelcase'
 import type { Path, State } from 's2s-babel-flow-types'
-import { getImportPath, template } from 's2s-utils'
+import { getImportPath, template, inheritsOpts } from 's2s-utils'
 
 const createObjectType = input =>
   template(`export type State = STATE`)({
@@ -15,16 +15,6 @@ const createObjectType = input =>
 function getParentDirName(path: string) {
   const parentPath = normalize(dirname(path)).split('/')
   return upperCamelCase(parentPath[parentPath.length - 1])
-}
-
-// TODO ignore all syntax error
-function inheritsOpts() {
-  return {
-    manipulateOptions(opts: Object, parserOpts: Object) {
-      parserOpts.plugins.push('flow')
-      parserOpts.plugins.push('objectRestSpread')
-    },
-  }
 }
 
 export default () => {

--- a/packages/s2s-utils/index.js
+++ b/packages/s2s-utils/index.js
@@ -5,6 +5,7 @@ const babelTemplate = require('babel-template')
 
 exports.getImportPath = getImportPath
 exports.template = template
+exports.inheritsOpts = inheritsOpts
 
 function trimExtension(path /* : string */, ext /* : string */ = '.js') {
   return extname(path) === ext ? path.replace(ext, '') : path
@@ -21,4 +22,14 @@ function getImportPath(from /* : string */, to /* : string */) /* : string */ {
 
 function template(code /* : string */, plugins /* :?string[] */ = ['flow']) {
   return babelTemplate(code, { sourceType: 'module', plugins })
+}
+
+function inheritsOpts() {
+  return {
+    manipulateOptions(opts /* : Object */, parserOpts /* : Object */) {
+      ;['flow', 'objectRestSpread'].forEach(plugin => {
+        parserOpts.plugins.push(plugin)
+      })
+    },
+  }
 }

--- a/packages/s2s-utils/index.test.js
+++ b/packages/s2s-utils/index.test.js
@@ -1,5 +1,5 @@
 // @flow
-import { getImportPath, template } from '.'
+import { getImportPath, template, inheritsOpts } from '.'
 
 test('getImportPath same folder', () => {
   const result = getImportPath('path/to/index.js', 'path/to/test.js')
@@ -19,4 +19,10 @@ test('getImportPath parent folder', () => {
 test('template', () => {
   const ast = template(`type Action = A`)()
   expect(ast).toMatchSnapshot()
+})
+
+test('inheritsOpts', () => {
+  const parserOpts = { plugins: [] }
+  inheritsOpts().manipulateOptions({}, parserOpts)
+  expect(parserOpts).toEqual({ plugins: ['flow', 'objectRestSpread'] })
 })


### PR DESCRIPTION
## Why
inheritは一つしか継承できないが、以下のようにすると複数継承できる。
flowとobjectRestSpreadは使用回数が多いためデフォルトで設定し、utilとしてs2sパッケージで使うことにする

```js
function inheritsOpts() {
  return {
    manipulateOptions(opts /* : Object */, parserOpts /* : Object */) {
      ;['flow', 'objectRestSpread'].forEach(plugin => {
        parserOpts.plugins.push(plugin)
      })
    },
  }
}
```