### PR TITLE
Add s2s-plugins-redux

### DIFF
--- a/packages/s2s-plugins-redux/index.js
+++ b/packages/s2s-plugins-redux/index.js
@@ -1,0 +1,74 @@
+// @flow
+const path = require('path')
+
+const actionTypesPlugin = require('babel-plugin-s2s-action-types').default
+const actionCreaterPlugin = require('babel-plugin-s2s-action-creater').default
+const reducerCaseCreaterPlugin = require('babel-plugin-s2s-reducer-case-creater')
+  .default
+const actionRootPlugin = require('babel-plugin-s2s-action-root').default
+const reducerTestCasePlugin = require('babel-plugin-s2s-reducer-test-case')
+  .default
+const stateRootPlugin = require('babel-plugin-s2s-state-root').default
+const reducerRootPlugin = require('babel-plugin-s2s-reducer-root').default
+
+const cwd = process.cwd()
+
+const getRootDir = (...x) => path.resolve(cwd, 'src', ...x)
+const getTyepDir = x => getRootDir('types', x)
+
+const rootReducerPath = getRootDir('reducer.js')
+const rootActionPath = getTyepDir('action.js')
+const rootStatePath = getTyepDir('state.js')
+
+const plugins = [
+  {
+    test: /actionTypes.js$/,
+    plugin: [actionTypesPlugin, { removePrefix: 'src/containers' }],
+  },
+  {
+    test: /actionTypes.js$/,
+    output: 'actions.js',
+    plugin: [actionCreaterPlugin],
+  },
+  {
+    test: /actionTypes.js$/,
+    input: 'reducer.js',
+    output: 'reducer.js',
+    plugin: [reducerCaseCreaterPlugin],
+  },
+  {
+    test: /actionTypes.js$/,
+    input: rootActionPath,
+    output: rootActionPath,
+    plugin: [
+      actionRootPlugin,
+      { input: 'src/**/actionTypes.js', output: rootActionPath },
+    ],
+  },
+  {
+    test: /containers\/.+reducer.js/,
+    input: 'reducer.test.js',
+    output: 'reducer.test.js',
+    plugin: [reducerTestCasePlugin],
+  },
+  {
+    test: /containers\/.+reducer.js/,
+    input: rootStatePath,
+    output: rootStatePath,
+    plugin: [
+      stateRootPlugin,
+      { input: 'src/containers/**/reducer.js', output: rootStatePath },
+    ],
+  },
+  {
+    test: /containers\/.+reducer.js/,
+    input: rootReducerPath,
+    output: rootReducerPath,
+    plugin: [
+      reducerRootPlugin,
+      { input: 'src/containers/**/reducer.js', output: rootReducerPath },
+    ],
+  },
+]
+
+module.exports = plugins

--- a/packages/s2s-plugins-redux/package.json
+++ b/packages/s2s-plugins-redux/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "s2s-plugins-redux",
+  "version": "0.0.0",
+  "description": "s2s plugins for redux",
+  "license": "MIT",
+  "repository": "akameco/s2s-plugins",
+  "author": {
+    "name": "akameco",
+    "email": "akameco.t@gmail.com",
+    "url": "akameco.github.io"
+  },
+  "engines": {
+    "node": ">=6"
+  },
+  "main": "index.js",
+  "files": ["index.js"],
+  "dependencies": {
+    "babel-plugin-s2s-action-creater": "^0.2.2",
+    "babel-plugin-s2s-action-root": "^0.3.2",
+    "babel-plugin-s2s-action-types": "^0.4.2",
+    "babel-plugin-s2s-reducer-case-creater": "^0.1.1",
+    "babel-plugin-s2s-reducer-root": "^0.2.2",
+    "babel-plugin-s2s-reducer-test-case": "^0.4.2",
+    "babel-plugin-s2s-state-root": "^0.2.2"
+  }
+}

--- a/packages/s2s-plugins-redux/readme.md
+++ b/packages/s2s-plugins-redux/readme.md
@@ -1,0 +1,42 @@
+# s2s-plugins-redux
+
+> s2s plugins for redux
+
+
+## Plugins
+
+### babel-plugin-s2s-action-creater
+### babel-plugin-s2s-action-root
+### babel-plugin-s2s-action-types
+### babel-plugin-s2s-reducer-case-creater
+### babel-plugin-s2s-reducer-root
+### babel-plugin-s2s-reducer-test-case
+### babel-plugin-s2s-state-root
+
+## Usage
+
+s2s.config.js
+
+```js
+const plugins = require('s2s-plugins-redux')
+
+module.exports = {
+  watch: './**/*.js',
+  plugins,
+  templates: [
+    { test: /containers\/.*\/index.js/, input: 'containers.js' },
+    { test: /components\/.*\/index.js/, input: 'components.js' },
+    { test: /components\/.*\/index.test.js/, input: 'component.test.js' },
+    { test: /reducer.js/, input: 'reducer.js' },
+    { test: /reducer.js/, input: 'reducer.test.js', output: 'reducer.test.js' },
+    { test: /reducer.js/, input: 'actionTypes.js', output: 'actionTypes.js' },
+    { test: /selectors.js/, input: 'selectors.js' },
+    { test: /selectors.test.js/, input: 'selectors.test.js' },
+    { test: /logic.js/, input: 'logic.js' },
+  ],
+}
+
+```
+
+### Examples
+[s2s-examples/shopping-cart](https://github.com/akameco/s2s-examples/tree/master/shopping-cart)


### PR DESCRIPTION
related https://github.com/akameco/s2s/issues/20

## Why
s2sを拡張する前にplugins集としてまとめて、それをconifgでconcatする方法を試す。
これによって、今の実装のままで依存の数を減らすことができる。